### PR TITLE
Support Hugo relref Shortcode to fix broken links

### DIFF
--- a/app/staticcms/public/index.html
+++ b/app/staticcms/public/index.html
@@ -10,6 +10,52 @@
         <script src="cms/static-cms-app.js"></script>
         <script>
             CMS.init();
+
+            const stripQuotes = (str) => {
+                let i = 0;
+                for (; i < str.length && (str[i] === '"' || str[i] === '\''); ++i)
+                    ;
+                let j = str.length;
+                for (; j > 0 && (str[j-1] === '"' || str[j-1] === '\''); --j)
+                    ;
+                return str.slice(i, j);
+            };
+
+            CMS.registerShortcode('relref', {
+                label: 'Relref',
+                openTag: '{{< ',
+                closeTag: ' >}}',
+                separator: ' ',
+                toProps: args => {
+                    if (args.length > 0) {
+                        const path = stripQuotes(args[0]);
+                        return {path};
+                    }
+
+                    return { path: '' };
+                },
+                toArgs: ({ path }) => {
+                    return [`"${stripQuotes(path)}"`];
+                },
+                control: ({ path, onChange }) => {
+                    const theme = useTheme();
+
+                    return h('input', {
+                        key: 'control-input',
+                        value: path || undefined,
+                        onChange: event => {
+                            onChange({ path: event.target.value });
+                        },
+                        style: {
+                            width: 'fit-content',
+                            backgroundColor: theme.background.main,
+                            color: theme.text.primary,
+                            padding: '4px 8px',
+                        },
+                    });
+                },
+                preview: ({ path }) => h('a', {href: path}, path),
+            });
         </script>
     </body>
 </html>


### PR DESCRIPTION
### Summary

Support Hugo's `{{< relref "/xyz" >}}` Shortcode.

The extension do not work quite the same as native widgets like the `<Link>` component.

Unfortunately all tries to use the existing components failed, Static CMS just isn't designed for that and changes to the markdown serialization/de-serialization functions would be needed.

Writing extension like this one seems simple, but there are a few tricky parts that required debugging:
- Spaces in start/end tags must match or Shortcodes won't apply
- Quotes in the Shortcode arguments caused issues during tests, the quotes are now removed for display and re-inserted on changes

### Alternative to this PR

Additionally/alternatively one could locate and fix the link parsing issue in Static CMS.
