### PR TITLE
Fix origins pattern to allow localhost and port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ LABEL org.opencontainers.image.description="Run static-cms with GitHub OAuth pro
 
 # Environment vars
 ENV LOGLEVEL=info
-ENV ORIGINS=http://localhost
+ENV ORIGINS=localhost
 #
 ENV GIT_HOSTNAME=
 ENV OAUTH_CLIENT_ID=

--- a/app/netlify-cms-github-oauth-provider/origins-pattern-fix.patch
+++ b/app/netlify-cms-github-oauth-provider/origins-pattern-fix.patch
@@ -1,0 +1,11 @@
+diff --git a/login_script.js b/login_script.js
+index d7ef9ca..c8b8db3 100644
+--- a/login_script.js
++++ b/login_script.js
+@@ -1,5 +1,5 @@
+ const REQUIRED_ORIGIN_PATTERN = 
+-  /^((\*|([\w_-]{2,}))\.)*(([\w_-]{2,})\.)+(\w{2,})(\,((\*|([\w_-]{2,}))\.)*(([\w_-]{2,})\.)+(\w{2,}))*$/
++  /^((\*|\d.\d.\d.\d|[\w_-]{2,})+(\.([\w_-]{2,}))*)(:\d+)?$/
+ 
+ if (!process.env.ORIGINS.match(REQUIRED_ORIGIN_PATTERN)) {
+   throw new Error('process.env.ORIGIN MUST be comma separated list \


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29451

### Summary

Fix an issue in `netlify-cms-github-oauth-provider` where localhost origins aren't permitted, effectively making local development work impossible.

This issue is also (incorrectly) fixed in some fork of the library, example: https://github.com/tire-allaite-moi/netlify-cms-github-oauth-provider/commit/37c553e2a119d0c9138b4a6366b5e18933744e8f